### PR TITLE
#2 Add `ember-test-waiters` to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@carto/carto-vl": "1.3.0",
     "ember-auto-import": "1.4.1",
     "ember-cli-babel": "^7.7.3",
-    "ember-cli-htmlbars": "^3.0.1"
+    "ember-cli-htmlbars": "^3.0.1",
+    "ember-test-waiters": "1.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",


### PR DESCRIPTION
Since `ember-test-waiters` is used in the deployed addon source, add it to the dependencies in addition to devDependencies.

This fixes Issue #2 

### Todo: 
Perhaps look into if there are other "waiter" libraries with similar functionality, but for application source code. It does seem that test-waiters may be originally meant for test suites.

